### PR TITLE
Moved local filesystem constants to a separate script

### DIFF
--- a/NonWordTranscriptionDirectories.praat
+++ b/NonWordTranscriptionDirectories.praat
@@ -1,0 +1,24 @@
+# NonWordTranscriptionDirectories.praat
+
+# https://github.com/LearningToTalk/NonWordTranscription
+
+# Author:    Mary Beckman
+# Date:       30 October 2013
+# Purpose:  Auxiliary script for specifying local filesystem constants
+
+# Directory from where to read in the segmented textgrid file.
+segmentDirectory$     = "Z:/DataAnalysis/NonWordRep/TimePoint1/Segmentation/SegmentedFiles"
+
+# Directory from where to read in the audio file.
+audioDirectory$       = "Z:/DataAnalysis/NonWordRep/TimePoint1/Recordings"
+
+# Directory from where to read in the audio file.
+wordListDirectory$    = "Z:/DataAnalysis/NonWordRep/TimePoint1/WordLists"
+
+# Directory for the transcription log file that is created the first time a file is opened for transription.
+transLogDirectory$      = "Z:\DataAnalysis\NonWordRep\TimePoint1\Transcription\Testing\TranscriptionLogs"
+
+# Directory for the transcription textgrid file that is created by the process of transription.
+transDirectory$  = "Z:\DataAnalysis\NonWordRep\TimePoint1\Transcription\Testing\TranscriptionTextGrids"
+
+


### PR DESCRIPTION
In preparation for sharing the task across multiple transcribers at both sites, changed script to move the local filesystem constants to a separate NonWordTranscriptionDirectories.praat script
