### PR TITLE
Moved local filesystem constants to a separate script

### DIFF
--- a/NonWordTranscriptionDirectories.praat
+++ b/NonWordTranscriptionDirectories.praat
@@ -1,0 +1,24 @@
+# NonWordTranscriptionDirectories.praat
+
+# https://github.com/LearningToTalk/NonWordTranscription
+
+# Author:    Mary Beckman
+# Date:       30 October 2013
+# Purpose:  Auxiliary script for specifying local filesystem constants
+
+# Directory from where to read in the segmented textgrid file.
+segmentDirectory$     = "Z:/DataAnalysis/NonWordRep/TimePoint1/Segmentation/SegmentedFiles"
+
+# Directory from where to read in the audio file.
+audioDirectory$       = "Z:/DataAnalysis/NonWordRep/TimePoint1/Recordings"
+
+# Directory from where to read in the audio file.
+wordListDirectory$    = "Z:/DataAnalysis/NonWordRep/TimePoint1/WordLists"
+
+# Directory for the transcription log file that is created the first time a file is opened for transription.
+transLogDirectory$      = "Z:\DataAnalysis\NonWordRep\TimePoint1\Transcription\Testing\TranscriptionLogs"
+
+# Directory for the transcription textgrid file that is created by the process of transription.
+transDirectory$  = "Z:\DataAnalysis\NonWordRep\TimePoint1\Transcription\Testing\TranscriptionTextGrids"
+
+


### PR DESCRIPTION
Original comment: Catching up with Tristan's changes in 2014-04 when Michelle Erskine and Jamie Anderson started their calibration exercise. 
Mary later realized that she had specified the wrong direction for the (opaque to such a UNIX dinosaur as Mary) pointy-clicky pull request command, so that she ended up merging from marybeckman/NonWordTranscription into LearningToTalk/NonWordTranscription with the cluttering but otherwise innocuous result that the useless NonWordTranscriptionDirectories.praat file was copied to the "master" LearningToTalk/NonWordTranscription repository.  She then fixed this by deleting that file.
