### PR TITLE
Rearranged initial part of trial loop, etc.

### DIFF
--- a/segment_features.praat
+++ b/segment_features.praat
@@ -14,7 +14,7 @@ omitted$   = "Omitted"
 other$ = "Other"
 unclassifiable$ = "Unclassifiable"
 to_be_determined$ = "TBA"
-
+missing_data$ = "NA"
 
 ##### CONSONANT -- MANNER
 # Manner feature values for consonants.


### PR DESCRIPTION
Rearranged initial part of trial loop so that transcriber can choose a segmented interval other than the first. Also changed treatment of "NonResponse" so that a 0-score interval is inserted instead of just skipping. Added "unclassifiable" as a possible transcription, but haven't tested it directly. 
